### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.9 as build
+
+RUN cd / && go get -v github.com/disintegration/gift github.com/nsf/termbox-go
+COPY main.go /main.go
+RUN cd / && \
+    CGO_ENABLED=0 GOOS=linux go build -a -tags "netgo static_build" -installsuffix netgo -ldflags "-w -s" -o invaders main.go
+
+FROM scratch
+LABEL maintainer "Sau Sheong Chang <sausheong@gmail.com>"
+
+CMD ["/invaders"]
+COPY imgs /imgs
+COPY --from=build /invaders /

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN cd / && \
 FROM scratch
 LABEL maintainer "Sau Sheong Chang <sausheong@gmail.com>"
 
+WORKDIR /
 CMD ["/invaders"]
 COPY imgs /imgs
 COPY --from=build /invaders /


### PR DESCRIPTION
Dockerfile for those, who like golang builds in the Docker container. It produces minimalistic Docker image (2.22MB). 
Docker build: `docker build -t invaders .`
Unfortunately, it doesn't work in my Putty, so I was not able to test it in my console. 
Public Docker image for testing: `docker run --rm -ti jangaraj/invaders`
